### PR TITLE
Display Recent Searches on Frontend

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import '../styles/Footer.css';
+import React from "react";
+import { Link } from "react-router-dom";
+import "../styles/Footer.css";
 
 interface FooterProps {
   onNavigateToAbout?: () => void;
@@ -14,7 +14,7 @@ const Footer: React.FC<FooterProps> = ({ onNavigateToAbout }) => {
       onNavigateToAbout();
     } else {
       // Dispatch custom event for navigation when prop is not available
-      window.dispatchEvent(new CustomEvent('navigateToAbout'));
+      window.dispatchEvent(new CustomEvent("navigateToAbout"));
     }
   };
 
@@ -24,23 +24,30 @@ const Footer: React.FC<FooterProps> = ({ onNavigateToAbout }) => {
         <div className="footer-logos">
           <img src="/logo.png" alt="Logo" className="footer-logo" />
           <img src="wikidata.png" alt="Wikidata logo" className="footer-logo" />
-          <Link href="https://www.wikidata.org/wiki/Wikidata:Introduction" target="_blank">
+          <Link
+            to="https://www.wikidata.org/wiki/Wikidata:Introduction"
+            target="_blank"
+          />
         </div>
 
         <div className="footer-content">
           <nav className="footer-nav">
             <div className="footer-nav-links">
-              <Link to="/about" onClick={handleAboutClick} className="footer-link">
+              <Link
+                to="/about"
+                onClick={handleAboutClick}
+                className="footer-link"
+              >
                 About Us
               </Link>
             </div>
           </nav>
 
           <div className="footer-external">
-            <a 
-              href="https://creativecommons.org/licenses/by-sa/4.0/" 
-              target="_blank" 
-              rel="noopener noreferrer" 
+            <a
+              href="https://creativecommons.org/licenses/by-sa/4.0/"
+              target="_blank"
+              rel="noopener noreferrer"
               className="footer-link footer-link-external"
             >
               CC BY-SA 4.0

--- a/client/src/components/HomePage.tsx
+++ b/client/src/components/HomePage.tsx
@@ -85,10 +85,14 @@ const HomePage: React.FC<HomePageProps> = ({ onSearch }) => {
     setCountry("");
   };
 
+  const onNavigateToAbout = () => {
+    console.log("Function not implemented.");
+  };
+
   return (
     <div className="home-page">
       <Header showBackButton={false} onNavigateToAbout={onNavigateToAbout} />
-      
+
       <main className="hero-section">
         <div className="hero-overlay">
           <h1 className="hero-title">SUPREME COURT CASES</h1>

--- a/client/src/components/HomePage.tsx
+++ b/client/src/components/HomePage.tsx
@@ -1,30 +1,101 @@
-import React, { useState } from 'react';
-import Header from './Header';
-import Footer from './Footer';
-import '../styles/HomePage.css';
+import React, { useState } from "react";
+import Header from "./Header";
+import Footer from "./Footer";
+import "../styles/HomePage.css";
 
 interface HomePageProps {
   onSearch: (query: string) => void;
 }
 
 const HomePage: React.FC<HomePageProps> = ({ onSearch }) => {
-  const [query, setQuery] = useState('');
+  interface CourtCase {
+    caseId: string;
+    title: string;
+    description: string;
+    date: string;
+    citation: string;
+    court: string;
+    judges: string;
+    sourceLabel: string;
+    articleUrl: string;
+  }
+  const [query, setQuery] = useState("");
+
+  const [year, setYear] = useState("");
+  const [judge, setJudge] = useState("");
+  const [country, setCountry] = useState("");
+  const [results, setResults] = useState<CourtCase[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchSearchResults = async (searchQuery: string) => {
+    setLoading(true);
+
+    try {
+      const response = await fetch(
+        `http://localhost:9090/search?q=${encodeURIComponent(searchQuery)}`
+      );
+      const data = await response.json();
+
+      if (data.success) {
+        setResults(data.results);
+      } else {
+        setResults([]);
+      }
+    } catch (error) {
+      console.error("Search error:", error);
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (query.trim()) {
       onSearch(query.trim());
+      fetchSearchResults(query.trim());
     }
+  };
+
+  const handleApplyFilters = async () => {
+    const params = new URLSearchParams();
+
+    if (year) params.append("year", year);
+    if (judge) params.append("judge", judge);
+    if (country) params.append("country", country);
+
+    console.log("params", params);
+
+    setLoading(true);
+
+    const response = await fetch(
+      `http://localhost:9090/browse?${params.toString()}`
+    );
+    const data = await response.json();
+
+    console.log("Filtered results:", data);
+
+    if (data.success) {
+      setResults(data.results);
+    }
+
+    setLoading(false);
+  };
+
+  const handleResetFilters = () => {
+    setYear("");
+    setJudge("");
+    setCountry("");
   };
 
   return (
     <div className="home-page">
       <Header showBackButton={false} />
-      
+
       <main className="hero-section">
         <div className="hero-overlay">
           <h1 className="hero-title">SUPREME COURT CASES</h1>
-          
+
           <form className="search-container" onSubmit={handleSubmit}>
             <div className="search-box">
               <input
@@ -41,8 +112,93 @@ const HomePage: React.FC<HomePageProps> = ({ onSearch }) => {
               </button>
             </div>
           </form>
+
+          <div className="filter-panel">
+            <select value={year} onChange={(e) => setYear(e.target.value)}>
+              <option value="">Select Year</option>
+              <option value="2010">2010</option>
+              <option value="2015">2015</option>
+              <option value="2020">2020</option>
+            </select>
+
+            <select value={judge} onChange={(e) => setJudge(e.target.value)}>
+              <option value="">Select Judge</option>
+              <option value="Atuguba">Atuguba</option>
+              <option value="Dotse">Dotse</option>
+            </select>
+
+            <select
+              value={country}
+              onChange={(e) => setCountry(e.target.value)}
+            >
+              <option value="">Select Country</option>
+              <option value="Ghana">Ghana</option>
+            </select>
+
+            <div className="filter-actions">
+              <button onClick={handleApplyFilters} className="apply-btn">
+                Apply Filters
+              </button>
+              <button onClick={handleResetFilters} className="reset-btn">
+                Reset
+              </button>
+            </div>
+          </div>
+          <br />
+
+          {loading && <p className="loading-text">Loading results...</p>}
+
+          {!loading && results.length === 0 && (
+            <p className="no-results">No results found.</p>
+          )}
         </div>
       </main>
+
+      <div className="results-section">
+        {!loading && results.length > 0 && (
+          <div className="table-wrapper">
+            <table className="results-table">
+              <thead>
+                <tr>
+                  <th>Case ID</th>
+                  <th>Title</th>
+                  <th>Description</th>
+                  <th>Date</th>
+                  <th>Citation</th>
+                  <th>Court</th>
+                  <th>Judges</th>
+                  <th>Source</th>
+                  <th>Article</th>
+                </tr>
+              </thead>
+
+              <tbody>
+                {results.map((item) => (
+                  <tr key={item.caseId}>
+                    <td>{item.caseId}</td>
+                    <td>{item.title}</td>
+                    <td>{item.description}</td>
+                    <td>{item.date}</td>
+                    <td>{item.citation}</td>
+                    <td>{item.court}</td>
+                    <td className="judges-cell">{item.judges}</td>
+                    <td>{item.sourceLabel}</td>
+                    <td>
+                      <a
+                        href={item.articleUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        View
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
 
       <Footer />
     </div>

--- a/client/src/components/HomePage.tsx
+++ b/client/src/components/HomePage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Header from "./Header";
 import Footer from "./Footer";
 import "../styles/HomePage.css";
+import RecentSearches from "./RecentSearches";
 
 interface HomePageProps {
   onSearch: (query: string) => void;
@@ -27,6 +28,7 @@ const HomePage: React.FC<HomePageProps> = ({ onSearch }) => {
   const [country, setCountry] = useState("");
   const [results, setResults] = useState<CourtCase[]>([]);
   const [loading, setLoading] = useState(false);
+  const [showRecent, setShowRecent] = useState(false);
 
   const fetchSearchResults = async (searchQuery: string) => {
     setLoading(true);
@@ -107,12 +109,22 @@ const HomePage: React.FC<HomePageProps> = ({ onSearch }) => {
                 className="search-input"
                 autoComplete="off"
                 required
+                onFocus={() => setShowRecent(true)}
               />
               <button type="submit" className="search-button">
                 <i className="fas fa-search"></i>
               </button>
             </div>
           </form>
+
+          <RecentSearches
+            visible={showRecent}
+            onClose={() => setShowRecent(false)}
+            onSelect={(title) => {
+              setQuery(title);
+              fetchSearchResults(title);
+            }}
+          />
 
           <div className="filter-panel">
             <select value={year} onChange={(e) => setYear(e.target.value)}>
@@ -157,8 +169,8 @@ const HomePage: React.FC<HomePageProps> = ({ onSearch }) => {
 
       <div className="results-section">
         {!loading && results.length > 0 && (
-          <div className="table-wrapper">
-            <table className="results-table">
+          <div className="filter-table-wrapper">
+            <table className="filter-results-table">
               <thead>
                 <tr>
                   <th>Case ID</th>

--- a/client/src/components/HomePage.tsx
+++ b/client/src/components/HomePage.tsx
@@ -64,16 +64,12 @@ const HomePage: React.FC<HomePageProps> = ({ onSearch }) => {
     if (judge) params.append("judge", judge);
     if (country) params.append("country", country);
 
-    console.log("params", params);
-
     setLoading(true);
 
     const response = await fetch(
       `http://localhost:9090/browse?${params.toString()}`
     );
     const data = await response.json();
-
-    console.log("Filtered results:", data);
 
     if (data.success) {
       setResults(data.results);

--- a/client/src/components/RecentSearches.tsx
+++ b/client/src/components/RecentSearches.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useRef, useState } from "react";
+import "../styles/RecentSearches.css";
+
+interface RecentSearch {
+  caseId: string;
+  query: string;
+  title: string;
+  judges: string;
+  date: string;
+}
+
+interface RecentSearchesProps {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (title: string) => void;
+}
+
+const RecentSearches: React.FC<RecentSearchesProps> = ({
+  visible,
+  onClose,
+  onSelect,
+}) => {
+  const [searches, setSearches] = useState<RecentSearch[]>([]);
+  const [deletedIds, setDeletedIds] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [onClose]);
+
+
+    const fetchRecentSearches = async () => {
+    
+    
+    setIsLoading(true);
+    try {
+      const res = await fetch("http://localhost:9090/search");
+      const json = await res.json();
+
+      if (json.success) {
+        const filtered = json.results
+          .slice(0, 50)
+          .filter((item: RecentSearch) => !deletedIds.includes(item.caseId));
+        setSearches(filtered);
+      }
+    } catch (error) {
+      console.error("Failed to fetch recent searches:", error);
+      setSearches([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (visible) {
+      fetchRecentSearches();
+    }
+  }, [visible, deletedIds]);
+
+  const handleDeleteSimulated = (caseId: string) => {
+    setDeletedIds((prev) => [...prev, caseId]);
+
+    setSearches((prev) => prev.filter((item) => item.caseId !== caseId));
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div ref={containerRef} className="recent-dropdown">
+      {isLoading && (
+        <div className="recent-loading">
+          <div className="loading-spinner"></div>
+          <span>Loading recent searches...</span>
+        </div>
+      )}
+      {!isLoading && searches.length === 0 && (
+        <div className="recent-empty">No recent searches</div>
+      )}
+
+      {!isLoading && searches.map((item, index) => (
+        <div key={index} className="recent-row">
+          <div
+            className="recent-item-info"
+            onClick={() => {
+              onSelect(item.title);
+              onClose();
+            }}
+          >
+            <div className="recent-title">
+              {item.title} <span className="recent-date">{item.date}</span>
+            </div>
+            <div className="recent-details">
+              <span className="recent-judges">{item.judges}</span>
+            </div>
+          </div>
+          <button
+            className="recent-delete"
+            onClick={() => handleDeleteSimulated(item.caseId)}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RecentSearches;

--- a/client/src/styles/HomePage.css
+++ b/client/src/styles/HomePage.css
@@ -233,7 +233,7 @@
   background-color: #cfcfcf;
 }
 
-.table-wrapper {
+.filter-table-wrapper {
   overflow-x: auto;
   margin-top: 30px;
   display: flex;
@@ -241,7 +241,7 @@
   justify-content: center;
 }
 
-.results-table {
+.filter-results-table {
   width: 100%;
   max-width: 1400px;
   border-collapse: collapse;
@@ -249,15 +249,15 @@
   font-size: 14px;
 }
 
-.results-table th,
-.results-table td {
+.filter-results-table th,
+.filter-results-table td {
   border: 1px solid #e0e0e0;
   padding: 10px;
   text-align: left;
   vertical-align: top;
 }
 
-.results-table th {
+.filter-results-table th {
   background-color: #1f88e7;
   color: #ffffff;
   position: sticky;
@@ -265,11 +265,11 @@
   z-index: 1;
 }
 
-.results-table tr:nth-child(even) {
+.filter-results-table tr:nth-child(even) {
   background-color: #f9f9f9;
 }
 
-.results-table tr:hover {
+.filter-results-table tr:hover {
   background-color: #f1f7ff;
 }
 
@@ -278,13 +278,13 @@
   white-space: normal;
 }
 
-.results-table a {
+.filter-results-table a {
   color: #1f88e7;
   text-decoration: none;
   font-weight: 500;
 }
 
-.results-table a:hover {
+.filter-results-table a:hover {
   text-decoration: underline;
 }
 

--- a/client/src/styles/HomePage.css
+++ b/client/src/styles/HomePage.css
@@ -10,7 +10,12 @@
   align-items: center;
   justify-content: center;
   position: relative;
-  background: linear-gradient(135deg, var(--primary-blue) 0%, var(--primary-blue-light) 50%, var(--accent-gold) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--primary-blue) 0%,
+    var(--primary-blue-light) 50%,
+    var(--accent-gold) 100%
+  );
   background-size: 400% 400%;
   animation: gradientShift 8s ease-in-out infinite;
   padding: var(--space-8) var(--space-4);
@@ -18,21 +23,37 @@
 }
 
 @keyframes gradientShift {
-  0%, 100% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
 }
 
 .hero-section::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: 
-    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 80% 80%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 40% 70%, rgba(255, 255, 255, 0.05) 0%, transparent 50%);
+  background: radial-gradient(
+      circle at 20% 20%,
+      rgba(255, 255, 255, 0.1) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      circle at 80% 80%,
+      rgba(255, 255, 255, 0.1) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      circle at 40% 70%,
+      rgba(255, 255, 255, 0.05) 0%,
+      transparent 50%
+    );
   pointer-events: none;
 }
 
@@ -67,8 +88,12 @@
 }
 
 @keyframes titleGlow {
-  from { text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3); }
-  to { text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3), 0 0 20px rgba(255, 255, 255, 0.3); }
+  from {
+    text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  }
+  to {
+    text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3), 0 0 20px rgba(255, 255, 255, 0.3);
+  }
 }
 
 .search-container {
@@ -107,8 +132,7 @@
 }
 
 .search-box:focus-within {
-  box-shadow: 
-    0 25px 50px -12px rgba(0, 0, 0, 0.25),
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25),
     0 0 0 4px rgba(59, 130, 246, 0.2);
   transform: scale(1.02);
 }
@@ -131,7 +155,11 @@
 
 .search-button {
   padding: var(--space-6) var(--space-8);
-  background: linear-gradient(135deg, var(--primary-blue), var(--primary-blue-light));
+  background: linear-gradient(
+    135deg,
+    var(--primary-blue),
+    var(--primary-blue-light)
+  );
   color: var(--white);
   border: none;
   cursor: pointer;
@@ -143,7 +171,11 @@
 }
 
 .search-button:hover {
-  background: linear-gradient(135deg, var(--primary-blue-dark), var(--primary-blue));
+  background: linear-gradient(
+    135deg,
+    var(--primary-blue-dark),
+    var(--primary-blue)
+  );
   transform: translateX(-2px);
 }
 
@@ -155,28 +187,129 @@
   font-size: var(--font-size-xl);
 }
 
+.filter-panel {
+  margin-top: 20px;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.filter-panel select {
+  padding: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  min-width: 160px;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.apply-btn {
+  background-color: #1f88e7;
+  color: #fff;
+  border: none;
+  padding: 10px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.reset-btn {
+  background-color: #e0e0e0;
+  color: #333;
+  border: none;
+  padding: 10px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.apply-btn:hover {
+  background-color: #166fc2;
+}
+
+.reset-btn:hover {
+  background-color: #cfcfcf;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  margin-top: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.results-table {
+  width: 100%;
+  max-width: 1400px;
+  border-collapse: collapse;
+  background-color: #ffffff;
+  font-size: 14px;
+}
+
+.results-table th,
+.results-table td {
+  border: 1px solid #e0e0e0;
+  padding: 10px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.results-table th {
+  background-color: #1f88e7;
+  color: #ffffff;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.results-table tr:nth-child(even) {
+  background-color: #f9f9f9;
+}
+
+.results-table tr:hover {
+  background-color: #f1f7ff;
+}
+
+.judges-cell {
+  max-width: 280px;
+  white-space: normal;
+}
+
+.results-table a {
+  color: #1f88e7;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.results-table a:hover {
+  text-decoration: underline;
+}
+
 /* Mobile Responsiveness */
 @media (max-width: 768px) {
   .hero-section {
     padding: var(--space-6) var(--space-3);
     min-height: calc(100vh - 120px);
   }
-  
+
   .hero-title {
     font-size: var(--font-size-3xl);
     margin-bottom: var(--space-8);
   }
-  
+
   .search-input {
     padding: var(--space-4) var(--space-6);
     font-size: var(--font-size-base);
   }
-  
+
   .search-button {
     padding: var(--space-4) var(--space-6);
     min-width: 60px;
   }
-  
+
   .search-button i {
     font-size: var(--font-size-lg);
   }
@@ -187,12 +320,12 @@
     font-size: var(--font-size-2xl);
     margin-bottom: var(--space-6);
   }
-  
+
   .search-input {
     padding: var(--space-3) var(--space-4);
     font-size: var(--font-size-sm);
   }
-  
+
   .search-button {
     padding: var(--space-3) var(--space-4);
     min-width: 50px;
@@ -206,7 +339,7 @@
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
-  
+
   .hero-section {
     background: var(--primary-blue);
   }

--- a/client/src/styles/RecentSearches.css
+++ b/client/src/styles/RecentSearches.css
@@ -1,0 +1,210 @@
+.recent-dropdown {
+  position: absolute;
+  top: 65%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 75%;
+  max-height: 500px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
+  border: 1px solid #e9ecef;
+  overflow: hidden;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease-out;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+    sans-serif;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.recent-empty {
+  padding: 24px;
+  text-align: center;
+  color: #6c757d;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.recent-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0;
+  border-bottom: 1px solid #f8f9fa;
+  transition: background-color 0.15s ease;
+  cursor: pointer;
+}
+
+.recent-row:last-child {
+  border-bottom: none;
+}
+
+.recent-row:hover {
+  background-color: #f8f9fa;
+}
+
+.recent-item-info {
+  flex: 1;
+  padding: 16px;
+  cursor: pointer;
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.recent-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: #212529;
+  line-height: 1.4;
+  margin-bottom: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  display: flex;
+
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.recent-details {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+  color: #6c757d;
+  line-height: 1.4;
+}
+
+.recent-judges {
+  font-weight: 400;
+  color: #495057;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+}
+
+.recent-date {
+  font-weight: 400;
+  color: #868e96;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.recent-delete {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-right: 12px;
+  border: none;
+  background: transparent;
+  color: #868e96;
+  font-size: 14px;
+  font-weight: 300;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  opacity: 0;
+}
+
+.recent-row:hover .recent-delete {
+  opacity: 1;
+}
+
+.recent-delete:hover {
+  background-color: #f1f3f5;
+  color: #fa5252;
+}
+
+.recent-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  gap: 16px;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #f3f3f3;
+  border-top: 3px solid #4285f4;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.recent-loading span {
+  color: #6c757d;
+  font-size: 14px;
+  font-weight: 400;
+  text-align: center;
+}
+
+@media (max-width: 480px) {
+  .recent-dropdown {
+    width: 100vw;
+    max-width: 350px;
+    right: -8px;
+    top: 32%;
+  }
+
+  .recent-details {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .recent-delete {
+    opacity: 1;
+    margin-right: 8px;
+  }
+}
+
+.recent-dropdown {
+  overflow-y: auto;
+}
+
+.recent-dropdown::-webkit-scrollbar {
+  width: 6px;
+}
+
+.recent-dropdown::-webkit-scrollbar-track {
+  background: #f8f9fa;
+  border-radius: 3px;
+}
+
+.recent-dropdown::-webkit-scrollbar-thumb {
+  background: #dee2e6;
+  border-radius: 3px;
+}
+
+.recent-dropdown::-webkit-scrollbar-thumb:hover {
+  background: #adb5bd;
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -2,6 +2,8 @@ import express, { Request, Response } from "express";
 import axios from "axios";
 import cors from "cors";
 
+
+
 const app = express();
 const PORT = process.env.PORT || 9090;
 
@@ -10,28 +12,28 @@ app.use(express.json());
 
 // ✅ Root endpoint
 app.get("/", (req: Request, res: Response) => {
-    res.json({
-        message: "Supreme Court of Ghana Cases API",
-        version: "1.0.0",
-        description: "API for searching Supreme Court of Ghana cases from Wikidata",
-        endpoints: {
-            search_all_cases: "GET /search",
-            search_with_query: "GET /search?q={query}",
-            examples: [
-                "http://localhost:9090/search",
-                "http://localhost:9090/search?q=human+rights",
-                "http://localhost:9090/search?q=constitution"
-            ]
-        },
-        documentation: "Use /search endpoint to get case data"
-    });
+  res.json({
+    message: "Supreme Court of Ghana Cases API",
+    version: "1.0.0",
+    description: "API for searching Supreme Court of Ghana cases from Wikidata",
+    endpoints: {
+      search_all_cases: "GET /search",
+      search_with_query: "GET /search?q={query}",
+      examples: [
+        "http://localhost:9090/search",
+        "http://localhost:9090/search?q=human+rights",
+        "http://localhost:9090/search?q=constitution",
+      ],
+    },
+    documentation: "Use /search endpoint to get case data",
+  });
 });
 
 // ✅ Search endpoint returning JSON
 app.get("/search", async (req: Request, res: Response) => {
-    const userQuery = (req.query.q as string)?.trim().toLowerCase() || "";
+  const userQuery = (req.query.q as string)?.trim().toLowerCase() || "";
 
-    const sparqlQuery = `
+  const sparqlQuery = `
     SELECT DISTINCT ?item ?itemLabel ?itemDescription ?date ?legal_citation ?courtLabel ?majority_opinionLabel ?sourceLabel (GROUP_CONCAT(DISTINCT ?judge; SEPARATOR = ", ") AS ?judges) WHERE {
       {
         SELECT DISTINCT * WHERE {
@@ -55,43 +57,150 @@ app.get("/search", async (req: Request, res: Response) => {
     GROUP BY ?item ?itemLabel ?itemDescription ?date ?legal_citation ?courtLabel ?majority_opinionLabel ?sourceLabel
     ORDER BY (?date)`;
 
-    try {
-        const url = `https://query.wikidata.org/sparql?query=${encodeURIComponent(sparqlQuery)}&format=json`;
-        const { data } = await axios.get(url, { timeout: 10000 });
+  try {
+    const url = `https://query.wikidata.org/sparql?query=${encodeURIComponent(
+      sparqlQuery
+    )}&format=json`;
+    const { data } = await axios.get(url, { timeout: 10000 });
 
-        const cases = (data as any).results.bindings
-            .map((item: any) => ({
-                caseId: item.item?.value.split("/").pop() || "Not Available",
-                title: item.itemLabel?.value || "Not Available",
-                description: item.itemDescription?.value || "No description available",
-                date: item.date?.value?.split("T")[0] || "Date not recorded",
-                citation: item.legal_citation?.value || "Citation unavailable",
-                court: item.courtLabel?.value || "Court not specified",
-                majorityOpinion: item.majority_opinionLabel?.value || "Majority opinion unavailable",
-                sourceLabel: item.sourceLabel?.value || "Source unavailable",
-                judges: item.judges?.value || "Judges unavailable",
-                articleUrl: item.item?.value || ""
-            }))
-            .filter((caseData: any) => {
-                if (!userQuery) return true; // Return all if no query
-                
-                return (
-                    caseData.title.toLowerCase().includes(userQuery) ||
-                    (caseData.description && caseData.description.toLowerCase().includes(userQuery)) ||
-                    (caseData.judges && caseData.judges.toLowerCase().includes(userQuery)) ||
-                    (caseData.citation && caseData.citation.toLowerCase().includes(userQuery)) ||
-                    (caseData.court && caseData.court.toLowerCase().includes(userQuery))
-                );
-            });
+    const cases = (data as any).results.bindings
+      .map((item: any) => ({
+        caseId: item.item?.value.split("/").pop() || "Not Available",
+        title: item.itemLabel?.value || "Not Available",
+        description: item.itemDescription?.value || "No description available",
+        date: item.date?.value?.split("T")[0] || "Date not recorded",
+        citation: item.legal_citation?.value || "Citation unavailable",
+        court: item.courtLabel?.value || "Court not specified",
+        majorityOpinion:
+          item.majority_opinionLabel?.value || "Majority opinion unavailable",
+        sourceLabel: item.sourceLabel?.value || "Source unavailable",
+        judges: item.judges?.value || "Judges unavailable",
+        articleUrl: item.item?.value || "",
+      }))
+      .filter((caseData: any) => {
+        if (!userQuery) return true; // Return all if no query
 
-        res.json({ success: true, results: cases });
-    } catch (error) {
-        console.error("❌ API Error:", error);
-        res.status(500).json({ success: false, error: "Please check your internet connection!" });
+        return (
+          caseData.title.toLowerCase().includes(userQuery) ||
+          (caseData.description &&
+            caseData.description.toLowerCase().includes(userQuery)) ||
+          (caseData.judges &&
+            caseData.judges.toLowerCase().includes(userQuery)) ||
+          (caseData.citation &&
+            caseData.citation.toLowerCase().includes(userQuery)) ||
+          (caseData.court && caseData.court.toLowerCase().includes(userQuery))
+        );
+      });
+
+    res.json({ success: true, results: cases });
+  } catch (error) {
+    console.error("❌ API Error:", error);
+    res
+      .status(500)
+      .json({
+        success: false,
+        error: "Please check your internet connection!",
+      });
+  }
+});
+
+// Browse endpoint
+
+interface CourtCase {
+  caseId: string;
+  title: string;
+  description: string;
+  date: string;
+  citation: string;
+  court: string;
+  judges: string;
+  sourceLabel: string;
+  articleUrl: string;
+}
+
+
+app.get("/browse", async (req: Request, res: Response) => {
+  const year = req.query.year as string | undefined;
+  const judge = req.query.judge as string | undefined;
+  const country = req.query.country as string | undefined;
+
+  const sparqlQuery = `
+    SELECT DISTINCT ?item ?itemLabel ?itemDescription ?date ?legal_citation ?courtLabel ?sourceLabel
+           (GROUP_CONCAT(DISTINCT ?judge; SEPARATOR = ", ") AS ?judges)
+    WHERE {
+      {
+        SELECT DISTINCT * WHERE {
+          ?item (wdt:P31/(wdt:P279*)) wd:Q114079647;
+                (wdt:P17/(wdt:P279*)) wd:Q117;
+                (wdt:P1001/(wdt:P279*)) wd:Q117;
+                (wdt:P793/(wdt:P279*)) wd:Q7099379;
+                wdt:P4884 ?court.
+          ?court (wdt:P279*) wd:Q1513611.
+        }
+        LIMIT 5000
+      }
+      ?item wdt:P577 ?date;
+            wdt:P1031 ?legal_citation;
+            wdt:P1433 ?source;
+            wdt:P1594 _:b1.
+      _:b1 rdfs:label ?judge.
+      FILTER(LANG(?judge) = "en")
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
     }
+    GROUP BY ?item ?itemLabel ?itemDescription ?date ?legal_citation ?courtLabel ?sourceLabel
+    ORDER BY (?date)
+    `;
+
+  try {
+    const url = `https://query.wikidata.org/sparql?query=${encodeURIComponent(
+      sparqlQuery
+    )}&format=json`;
+    const { data } = await axios.get(url, { timeout: 10000 });
+
+    let cases: CourtCase[] = (data as any).results.bindings.map(
+      (item: any): CourtCase => ({
+        caseId: item.item?.value.split("/").pop() || "N/A",
+        title: item.itemLabel?.value || "N/A",
+        description: item.itemDescription?.value || "",
+        date: item.date?.value?.split("T")[0] || "",
+        citation: item.legal_citation?.value || "",
+        court: item.courtLabel?.value || "",
+        judges: item.judges?.value || "",
+        sourceLabel: item.sourceLabel?.value || "",
+        articleUrl: item.item?.value || "",
+      })
+    );
+
+    
+    if (year) {
+      cases = cases.filter((c) => c.date.startsWith(year));
+    }
+
+    if (judge) {
+      cases = cases.filter((c) =>
+        c.judges.toLowerCase().includes(judge.toLowerCase())
+      );
+    }
+
+    if (country) {
+      cases = cases.filter((c) =>
+        c.court.toLowerCase().includes(country.toLowerCase())
+      );
+    }
+
+    res.json({
+      success: true,
+      mode: "browse",
+      filters: { year, judge, country },
+      results: cases,
+    });
+  } catch (error) {
+    console.error("Browse API Error:", error);
+    res.status(500).json({ success: false, error: "Browse request failed" });
+  }
 });
 
 // Start server
 app.listen(PORT, () => {
-    console.log(`✅ Server running on http://localhost:${PORT}`);
+  console.log(`✅ Server running on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
Description: Fetch and display stored recent searches in a clean, scrollable UI component.

Domain: Design (UI)

Difficulty: Intermediate

Steps:

Build a UI for displaying recent searches.
Connect to the backend recent-search API.
Add a clear button to remove entries.
Test the display on mobile and desktop.
Expected Outcome:
Users see a list of their recent searches and can click to revisit them.

below is the screenshot of the updated ui

<img width="1243" height="953" alt="image" src="https://github.com/user-attachments/assets/ef18f575-4c6b-463b-af05-793467a3d192" />
